### PR TITLE
account.expires_in isn't supported anymore

### DIFF
--- a/docs/docs/tutorials/refresh-token-rotation.md
+++ b/docs/docs/tutorials/refresh-token-rotation.md
@@ -61,7 +61,7 @@ async function refreshAccessToken(token) {
     return {
       ...token,
       accessToken: refreshedTokens.access_token,
-      accessTokenExpires: Date.now() + refreshedTokens.expires_in * 1000,
+      accessTokenExpires: Date.now() + refreshedTokens.expires_at * 1000,
       refreshToken: refreshedTokens.refresh_token ?? token.refreshToken, // Fall back to old refresh token
     }
   } catch (error) {
@@ -88,7 +88,7 @@ export default NextAuth({
       if (account && user) {
         return {
           accessToken: account.access_token,
-          accessTokenExpires: Date.now() + account.expires_in * 1000,
+          accessTokenExpires: Date.now() + account.expires_at * 1000,
           refreshToken: account.refresh_token,
           user,
         }


### PR DESCRIPTION
Problem: 
account.expires_in method is no longer supported and as a result, the comparison at line number 98 always returns true which leads to generation of a refresh token every time.

Solution:
On line numbers 64 and 91, I've updated the expires_in method to expires_at method and now the refresh token is generated only if the primary access token expires!

<!--
Thanks for your interest in the project. Bugs filed and PRs submitted are appreciated!

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

## ☕️ Reasoning
account.expires_in method is no longer supported and as a result, the comparison at line number 98 always returns true which leads to generation of a refresh token every time.

On line numbers 64 and 91, I've updated the expires_in method to expires_at method and now the refresh token is generated only if the primary access token expires!

## 🧢 Checklist

- [x] Documentation
- [ ] Tests
- [x] Ready to be merged

## 🎫 Affected issues

Please [scout and link issues](https://github.com/nextauthjs/next-auth/issues) that might be solved by this PR.

Fixes: Multiple requests for refresh token aren't generated anymore

## 📌 Resources

- [Contributing guidelines](./CONTRIBUTING.md)
- [Code of conduct](./CODE_OF_CONDUCT.md)
- [Contributing to Open Source](https://kcd.im/pull-request)
